### PR TITLE
fix: Background imgのaltを空文字指定に変更

### DIFF
--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -25,7 +25,7 @@ const Login: NextPage = () => {
           `}
           layout="fill"
           src="/images/background.png"
-          alt="Background Image"
+          alt=""
         />
         <div
           css={(theme: Theme) => css`

--- a/pages/auth/register.tsx
+++ b/pages/auth/register.tsx
@@ -25,7 +25,7 @@ const Home: NextPage = () => {
           `}
           layout="fill"
           src="/images/background.png"
-          alt="Background Image"
+          alt=""
         />
         <div
           css={(theme: Theme) => css`


### PR DESCRIPTION
前回のプルリクエスト(#22)をマージしてしまったので、新しくプルリクエストを作って修正。

## 関連する issue

無し

## 変更の概要

- #22 
- Background imgのaltを空文字指定に変更

## やったこと

- [x] Background imgのaltを空文字指定に変更

## 課題

なし

## 備考

なし
