### PR TITLE
feat: ナビゲーションガードの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "17.0.2",
     "recoil": "^0.6.1",
     "recoil-persist": "^4.0.0",
-    "ress": "^4.0.0"
+    "ress": "^4.0.0",
+    "swr": "^1.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,15 +10,18 @@ declare module '@emotion/react' {
 }
 
 import { RecoilRoot } from 'recoil';
+import { AuthProvider } from '../providers/AuthProvider';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <RecoilRoot>
-        <Global styles={GlobalStyle} />
-        <ThemeProvider theme={defaultTheme}>
-          <Component {...pageProps} />
-        </ThemeProvider>
+        <AuthProvider>
+          <Global styles={GlobalStyle} />
+          <ThemeProvider theme={defaultTheme}>
+            <Component {...pageProps} />
+          </ThemeProvider>
+        </AuthProvider>
       </RecoilRoot>
     </>
   );

--- a/pages/auth/login.tsx
+++ b/pages/auth/login.tsx
@@ -28,7 +28,6 @@ const Login: NextPage = () => {
       if (e instanceof Error) {
         console.log('通信エラー: ' + e.message);
       }
-    } finally {
       setLoading(false);
     }
   };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,23 @@
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import { userTokenState } from '../states';
+import { useRecoilState } from 'recoil';
+
+const Home: NextPage = () => {
+  const [, setUserToken] = useRecoilState(userTokenState);
+
+  const logout = () => {
+    setUserToken('');
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Takanuma Curriculum | All Categories</title>
+      </Head>
+      <button onClick={logout}>ログアウト</button>
+    </>
+  );
+};
+
+export default Home;

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -1,0 +1,54 @@
+import { SWRConfig } from 'swr';
+import { useRecoilState } from 'recoil';
+import { userTokenState } from '../states';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const isAuthPath = (path: string) => {
+  return path.startsWith('/auth');
+};
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter();
+  const [userToken] = useRecoilState(userTokenState);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (userToken && isAuthPath(router.pathname)) {
+      router.push('/');
+      return;
+    }
+
+    if (!userToken && !isAuthPath(router.pathname)) {
+      router.push('/auth/register');
+      return;
+    }
+
+    setLoading(false);
+  }, [userToken, router]);
+
+  if (loading) {
+    return <></>;
+  }
+
+  if (!userToken) {
+    return <>{children}</>;
+  }
+
+  return (
+    <SWRConfig
+      value={{
+        fetcher: (resource, init) =>
+          fetch(process.env.NEXT_PUBLIC_API_ORIGIN + resource, {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: 'Bearer ' + userToken,
+            },
+            ...init,
+          }).then((res) => res.json()),
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+};

--- a/providers/AuthProvider.tsx
+++ b/providers/AuthProvider.tsx
@@ -20,7 +20,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     if (!userToken && !isAuthPath(router.pathname)) {
-      router.push('/auth/register');
+      router.push('/auth/login');
       return;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11104,6 +11104,11 @@ svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swr@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.2.1.tgz#c21a4fe2139cb1c4630450589b5b5add947a9d41"
+  integrity sha512-1cuWXqJqXcFwbgONGCY4PHZ8v05009JdHsC3CIC6u7d00kgbMswNr1sHnnhseOBxtzVqcCNpOHEgVDciRer45w==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
#29 の続きです。

## 関連する issue

Closes #27 

## 変更の概要

-  ナビゲーションガードの実装

## やったこと

- [x] SWRの導入(今回は使ってないですが、今後使っていこうと思ってます)
- [x] ログイン状態 で尚且 認証画面にいる 時には、タスク一覧画面に遷移させる
- [x] ログアウト状態 で尚且 タスク一覧画面 のときには、認証画面に遷移させる
- [x] 正常なときには遷移はせずそのまま表示
- [x] ログイン状態と遷移先の判別が出来るまでは、何も表示しない

## 課題

- 以下のエラーが出ている→解決しました。

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

## 備考

- イシューを整理したい。(作業とレビューがしやすい為にはどういうふうに分けるのが適切か考えてみます🤔)
